### PR TITLE
Updated cracks to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "3.3.0",
     "coveralls": "2.11.4",
-    "cracks": "3.0.2",
+    "cracks": "3.1.0",
     "istanbul-harmony": "0.3.16",
     "jsdoc": "3.3.3",
     "mocha": "2.3.3",


### PR DESCRIPTION
:rocket:

cracks just published version 3.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/semantic-release/cracks/releases/tag/v3.1.0)

<a name"3.1.0"></a>
## 3.1.0 (2015-10-07)


#### Features

* **errors:** log stderr when encountering errors during child_process.exec ([d695129f](https://github.com/semantic-release/cracks/commit/d695129f))

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [4e827ba](https://github.com/semantic-release/cracks/commit/4e827ba135bd1bc2c2238f7a3755f8498abec53d): Merge pull request #1 from marionebl/feat/error-loggin
- [d695129](https://github.com/semantic-release/cracks/commit/d695129f21137d7575691bbe77c272fe4a6e10e5): feat(errors): log stderr when encountering errors during child_process.exec
- [b3db077](https://github.com/semantic-release/cracks/commit/b3db077b9fe67556861404382754ea92ea3c776c): docs(README): add basic docs

See the [full diff](https://github.com/semantic-release/cracks/compare/2fc4c21898552a7e0b6e1c22956e7dfdbbb291a0...4e827ba135bd1bc2c2238f7a3755f8498abec53d).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>